### PR TITLE
Should use a single DataLoader per query

### DIFF
--- a/graphql-service/pom.xml
+++ b/graphql-service/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>io.engagingspaces</groupId>
             <artifactId>vertx-dataloader</artifactId>
-            <version>0.9.2</version>
+            <version>0.9.4</version>
         </dependency>
 
         <dependency>

--- a/graphql-service/src/main/java/com/github/bmsantos/graphql/AppVerticle.java
+++ b/graphql-service/src/main/java/com/github/bmsantos/graphql/AppVerticle.java
@@ -3,8 +3,10 @@ package com.github.bmsantos.graphql;
 import javax.inject.Inject;
 
 import com.github.bmsantos.graphql.apigen.guice.AppModule;
+import com.github.bmsantos.graphql.apigen.resolvers.VehicleResolver;
 import com.github.bmsantos.graphql.model.guice.GuiceModule;
 import com.github.bmsantos.graphql.rest.GraphQLHandler;
+import com.google.inject.Injector;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -32,11 +34,18 @@ public class AppVerticle extends AbstractVerticle {
 
   @Override
   public void start(final Future<Void> startFuture) throws Exception {
-    createInjector(new GuiceModule(), new AppModule()).injectMembers(this);
+    final Injector injector = createInjector(new GuiceModule(), new AppModule());
+    context.put("injector", injector);
+    injector.injectMembers(this);
+
 
     final Router router = router(vertx);
     router.route().handler(BodyHandler.create());
     router.post("/graphql").handler(graphQLHandler);
+
+//    vertx.eventBus()
+//      .consumer("vehicle_publisher")
+//      .handler(VehicleResolver::handleVehicleRequest);
 
     startHttpServer(router).setHandler(startFuture.completer());
   }

--- a/graphql-service/src/main/java/com/github/bmsantos/graphql/apigen/resolvers/RentalResolver.java
+++ b/graphql-service/src/main/java/com/github/bmsantos/graphql/apigen/resolvers/RentalResolver.java
@@ -2,48 +2,45 @@ package com.github.bmsantos.graphql.apigen.resolvers;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import javax.inject.Inject;
 
+import com.github.bmsantos.graphql.dataloaders.DataLoaders;
 import com.github.bmsantos.graphql.model.rental.Rental;
 import com.github.bmsantos.graphql.model.rental.Rental.Unresolved;
 import com.github.bmsantos.graphql.rest.RestClient;
-import com.google.common.collect.Lists;
 import io.engagingspaces.vertx.dataloader.DataLoader;
-import io.vertx.core.Future;
 import io.vertx.core.logging.Logger;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 
 import static com.github.bmsantos.graphql.utils.CompletableObserver.completableObserver;
 import static com.github.bmsantos.graphql.utils.VertxCompletableFutureUtils.completedVertxCompletableFuture;
-import static io.vertx.core.CompositeFuture.all;
-import static io.vertx.core.Future.future;
 import static io.vertx.core.Vertx.currentContext;
 import static io.vertx.core.logging.LoggerFactory.getLogger;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 import static me.escoffier.vertx.completablefuture.VertxCompletableFuture.from;
 
 public class RentalResolver implements Rental.AsyncResolver {
   private static final Logger log = getLogger(RentalResolver.class);
 
-  @Inject
-  private RestClient restClient;
-
   @Override
   public CompletableFuture<List<Rental>> resolve(final List<Rental> unresolved) {
+    return null;
+  }
+
+  @Override
+  public CompletableFuture<List<Rental>> resolve(final Object context, final List<Rental> unresolved) {
     log.debug("Fetching all active rentals");
+
+    final DataLoaders dataLoaders = (DataLoaders) context;
 
     if (!requireNonNull(unresolved).isEmpty()) {
       final Rental rental = unresolved.get(0);
-      return processArgumentsQuery(requireNonNull(rental));
+      return processArgumentsQuery(dataLoaders.getRentalDataLoader(), requireNonNull(rental));
     }
 
-    return processQueryAll();
+    return processQueryAll(dataLoaders.getRestClient());
   }
 
-  private CompletableFuture<List<Rental>> processArgumentsQuery(final Rental rental) {
-    final DataLoader<Long, List<Rental>> dataLoader = getDataLoader();
-
+  private CompletableFuture<List<Rental>> processArgumentsQuery(final DataLoader<Long, List<Rental>> dataLoader, final Rental rental) {
     if (rental.getClass().equals(Unresolved.class)) {
       final Long id = rental.getId();
       log.debug("Fetching rental with id: " + id);
@@ -55,30 +52,13 @@ public class RentalResolver implements Rental.AsyncResolver {
         dataLoader.dispatch();
       }
     }
-
     return completedVertxCompletableFuture(null);
   }
 
-  private CompletableFuture<List<Rental>> processQueryAll() {
+  private CompletableFuture<List<Rental>> processQueryAll(final RestClient restClient) {
     final VertxCompletableFuture<List<Rental>> future = new VertxCompletableFuture<>();
     restClient.findAllRentals()
       .subscribe(completableObserver(future));
     return future;
   }
-
-  private DataLoader<Long, List<Rental>> getDataLoader() {
-    return new DataLoader<>(keys -> {
-      List<Future> futures = keys.stream().map(key -> {
-
-        final Future<List<Rental>> future = future();
-        restClient.findRentalById(key)
-          .map(Lists::newArrayList)
-          .subscribe(completableObserver(future));
-
-        return future;
-      }).collect(toList());
-      return all(futures);
-    });
-  }
-
 }

--- a/graphql-service/src/main/java/com/github/bmsantos/graphql/apigen/resolvers/VehicleResolver.java
+++ b/graphql-service/src/main/java/com/github/bmsantos/graphql/apigen/resolvers/VehicleResolver.java
@@ -2,44 +2,37 @@ package com.github.bmsantos.graphql.apigen.resolvers;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import javax.inject.Inject;
 
+import com.github.bmsantos.graphql.dataloaders.DataLoaders;
 import com.github.bmsantos.graphql.model.vehicles.Vehicle;
 import com.github.bmsantos.graphql.model.vehicles.Vehicle.Unresolved;
-import com.github.bmsantos.graphql.rest.RestClient;
-import com.google.common.collect.Lists;
 import io.engagingspaces.vertx.dataloader.DataLoader;
-import io.vertx.core.Future;
 import io.vertx.core.logging.Logger;
 
-import static com.github.bmsantos.graphql.utils.CompletableObserver.completableObserver;
 import static com.github.bmsantos.graphql.utils.VertxCompletableFutureUtils.completedVertxCompletableFuture;
-import static io.vertx.core.CompositeFuture.all;
-import static io.vertx.core.Future.future;
 import static io.vertx.core.Vertx.currentContext;
 import static io.vertx.core.logging.LoggerFactory.getLogger;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 import static me.escoffier.vertx.completablefuture.VertxCompletableFuture.from;
 
 public class VehicleResolver implements Vehicle.AsyncResolver {
   private static final Logger log = getLogger(VehicleResolver.class);
 
-  @Inject
-  private RestClient restClient;
-
   @Override
   public CompletableFuture<List<Vehicle>> resolve(final List<Vehicle> unresolved) {
+    return null;
+  }
+
+  @Override
+  public CompletableFuture<List<Vehicle>> resolve(final Object context, final List<Vehicle> unresolved) {
     if (!requireNonNull(unresolved).isEmpty()) {
       final Vehicle vehicle = unresolved.get(0);
-      return processRentalVehicle(requireNonNull(vehicle));
+      return processRentalVehicle(((DataLoaders)context).getVehicleDataLoader(), requireNonNull(vehicle));
     }
     return completedVertxCompletableFuture(null);
   }
 
-  private CompletableFuture<List<Vehicle>> processRentalVehicle(final Vehicle vehicle) {
-    final DataLoader<Long, List<Vehicle>> dataLoader = getDataLoader();
-
+  private CompletableFuture<List<Vehicle>> processRentalVehicle(final DataLoader<Long, List<Vehicle>> dataLoader, final Vehicle vehicle) {
     if (vehicle.getClass().equals(Unresolved.class)) {
       final Long id = vehicle.getId();
       log.debug("Fetching vehicle for rental id: " + id);
@@ -51,23 +44,6 @@ public class VehicleResolver implements Vehicle.AsyncResolver {
         dataLoader.dispatch();
       }
     }
-
     return completedVertxCompletableFuture(null);
   }
-
-  private DataLoader<Long, List<Vehicle>> getDataLoader() {
-    return new DataLoader<>(keys -> {
-      List<Future> futures = keys.stream().map(key -> {
-
-        final Future<List<Vehicle>> future = future();
-        restClient.findVehicleById(key)
-          .map(Lists::newArrayList)
-          .subscribe(completableObserver(future));
-
-        return future;
-      }).collect(toList());
-      return all(futures);
-    });
-  }
-
 }

--- a/graphql-service/src/main/java/com/github/bmsantos/graphql/dataloaders/DataLoaders.java
+++ b/graphql-service/src/main/java/com/github/bmsantos/graphql/dataloaders/DataLoaders.java
@@ -1,0 +1,87 @@
+package com.github.bmsantos.graphql.dataloaders;
+
+import java.util.List;
+
+import com.github.bmsantos.graphql.model.customer.Customer;
+import com.github.bmsantos.graphql.model.rental.Rental;
+import com.github.bmsantos.graphql.model.vehicles.Vehicle;
+import com.github.bmsantos.graphql.rest.RestClient;
+import com.google.common.collect.Lists;
+import io.engagingspaces.vertx.dataloader.DataLoader;
+import io.vertx.core.Future;
+
+import static com.github.bmsantos.graphql.utils.CompletableObserver.completableObserver;
+import static io.vertx.core.CompositeFuture.all;
+import static io.vertx.core.Future.future;
+import static java.util.Objects.isNull;
+import static java.util.stream.Collectors.toList;
+
+public class DataLoaders {
+
+  private RestClient restClient;
+  private DataLoader<Long, List<Customer>> customerDataLoader;
+  private DataLoader<Long, List<Vehicle>> vehicleDataLoader;
+  private DataLoader<Long, List<Rental>> rentalDataLoader;
+
+  public DataLoaders(final RestClient restClient) {
+    this.restClient = restClient;
+  }
+
+  public RestClient getRestClient() {
+    return restClient;
+  }
+
+  public DataLoader<Long, List<Customer>> getCustomerDataLoader() {
+    if (isNull(customerDataLoader)) {
+      customerDataLoader = new DataLoader<>(keys -> {
+        List<Future> futures = keys.stream().map(key -> {
+
+          final Future<List<Customer>> future = future();
+          restClient.findCustomerById(key)
+            .map(Lists::newArrayList)
+            .subscribe(completableObserver(future));
+
+          return future;
+        }).collect(toList());
+        return all(futures);
+      });
+    }
+    return customerDataLoader;
+  }
+
+  public DataLoader<Long, List<Vehicle>> getVehicleDataLoader() {
+    if (isNull(vehicleDataLoader)) {
+      vehicleDataLoader = new DataLoader<>(keys -> {
+        List<Future> futures = keys.stream().map(key -> {
+
+          final Future<List<Vehicle>> future = future();
+          restClient.findVehicleById(key)
+            .map(Lists::newArrayList)
+            .subscribe(completableObserver(future));
+
+          return future;
+        }).collect(toList());
+        return all(futures);
+      });
+    }
+    return vehicleDataLoader;
+  }
+
+  public DataLoader<Long, List<Rental>> getRentalDataLoader() {
+    if (isNull(rentalDataLoader)) {
+      rentalDataLoader = new DataLoader<>(keys -> {
+        List<Future> futures = keys.stream().map(key -> {
+
+          final Future<List<Rental>> future = future();
+          restClient.findRentalById(key)
+            .map(Lists::newArrayList)
+            .subscribe(completableObserver(future));
+
+          return future;
+        }).collect(toList());
+        return all(futures);
+      });
+    }
+    return rentalDataLoader;
+  }
+}

--- a/graphql-service/src/main/java/com/github/bmsantos/graphql/rest/GraphQLHandler.java
+++ b/graphql-service/src/main/java/com/github/bmsantos/graphql/rest/GraphQLHandler.java
@@ -5,6 +5,7 @@ import java.util.concurrent.CompletionStage;
 
 import javax.inject.Inject;
 
+import com.github.bmsantos.graphql.dataloaders.DataLoaders;
 import com.github.bmsantos.graphql.engine.GraphQLEngine;
 import graphql.ExecutionResult;
 import io.vertx.core.Handler;
@@ -26,6 +27,9 @@ public class GraphQLHandler implements Handler<RoutingContext> {
   @Inject
   private GraphQLEngine graphQL;
 
+  @Inject
+  private RestClient restClient;
+
   @Override
   public void handle(final RoutingContext ctx) {
     final String body = ctx.getBody().toString();
@@ -46,7 +50,7 @@ public class GraphQLHandler implements Handler<RoutingContext> {
         log.debug("Executing Query: " + json);
 
         final CompletionStage<ExecutionResult> future =
-          graphQL.engine().executeAsync(query, operationName, null, variables);
+          graphQL.engine().executeAsync(query, operationName, new DataLoaders(restClient), variables);
 
         future.handle((result, throwable) -> {
           final String doc = Json.encode(result);

--- a/graphql-service/src/test/java/com/github/bmsantos/graphql/apigen/resolvers/TestableCustomerResolver.java
+++ b/graphql-service/src/test/java/com/github/bmsantos/graphql/apigen/resolvers/TestableCustomerResolver.java
@@ -34,4 +34,9 @@ public class TestableCustomerResolver implements Customer.AsyncResolver {
 
     return completedVertxCompletableFuture(newArrayList(customers.values())); // is query all
   }
+
+  @Override
+  public CompletableFuture<List<Customer>> resolve(final Object context, final List<Customer> list) {
+    return null;
+  }
 }

--- a/graphql-service/src/test/java/com/github/bmsantos/graphql/apigen/resolvers/TestableRentalResolver.java
+++ b/graphql-service/src/test/java/com/github/bmsantos/graphql/apigen/resolvers/TestableRentalResolver.java
@@ -34,4 +34,9 @@ public class TestableRentalResolver implements Rental.AsyncResolver {
 
     return completedVertxCompletableFuture(newArrayList(rentals.values())); // is query all
   }
+
+  @Override
+  public CompletableFuture<List<Rental>> resolve(final Object context, final List<Rental> list) {
+    return null;
+  }
 }

--- a/graphql-service/src/test/java/com/github/bmsantos/graphql/apigen/resolvers/TestableVehicleResolver.java
+++ b/graphql-service/src/test/java/com/github/bmsantos/graphql/apigen/resolvers/TestableVehicleResolver.java
@@ -34,4 +34,9 @@ public class TestableVehicleResolver implements Vehicle.AsyncResolver {
 
     return completedVertxCompletableFuture(newArrayList(vehicles.values())); // is query all
   }
+
+  @Override
+  public CompletableFuture<List<Vehicle>> resolve(final Object context, final List<Vehicle> list) {
+    return null;
+  }
 }


### PR DESCRIPTION
Added required modifications that ensure that a single DataLoader is used per query.
When using cache, a request for the same key should not happen twice.

Issue #2